### PR TITLE
Added Monochrome Icon

### DIFF
--- a/res/mipmap-anydpi-v26/icon.xml
+++ b/res/mipmap-anydpi-v26/icon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/res/mipmap-anydpi-v26/icon_round.xml
+++ b/res/mipmap-anydpi-v26/icon_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
I added a Monochrome Icon, so that the Icon matches with the System.

Examples:


![Screenshot_20230223_143030_One UI Home](https://user-images.githubusercontent.com/86848811/220921253-13e973ba-f9fc-46ab-825f-b747c373e24b.jpg)
![Screenshot_20230223_143100_One UI Home](https://user-images.githubusercontent.com/86848811/220921256-40cb215e-0ccf-44be-9e2d-a1d42ad6149d.jpg)
![Screenshot_20230223_143129_One UI Home](https://user-images.githubusercontent.com/86848811/220921260-2a786463-0c86-44bf-b5ea-207f758ce4cc.jpg)
