### PR TITLE
Update SMSHelper.java

### DIFF
--- a/src/org/kde/kdeconnect/Helpers/SMSHelper.java
+++ b/src/org/kde/kdeconnect/Helpers/SMSHelper.java
@@ -332,8 +332,10 @@ public class SMSHelper {
                         switch (transportType) {
                             case SMS:
                                 toReturn.add(parseSMS(context, messageInfo));
+                                break;
                             case MMS:
                                 toReturn.add(parseMMS(context, messageInfo, userPhoneNumbers));
+                                break;
                         }
                     } catch (Exception e) {
                         // Swallow exceptions in case we get an error reading one message so that we


### PR DESCRIPTION
In the original kdeconnect it has break statements here. Without the break all messages are handled as MMS; causing error messages (and can't display the content of message)